### PR TITLE
Also export default activity and event ports of a task model

### DIFF
--- a/orogen/orogen_plugin.rb
+++ b/orogen/orogen_plugin.rb
@@ -83,8 +83,10 @@ class ModelExporterPlugin <  OroGen::Spec::TaskModelExtension
             taskHash['Plugins'] = {'transformer' => {'Frames' => transformer.available_frames.to_a,
                                    'Transformations' => transformer.needed_transformations.map{|t| {"From" => t.from, "To" => t.to} } }}
         end 
-        
 
+        taskHash['defaultActivity'] = task.default_activity
+        taskHash['eventPorts'] = task.event_ports.keys
+        
         doc[moduleName][taskName] = taskHash
         
         modelYML = Psych.dump(doc);


### PR DESCRIPTION
The YAML representation of a oroGen component is more complete if it also contains information about the default activity and event ports. This PR adds functionality to export this information.