### PR TITLE
Make sure orogen_model_exporter installs properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/orogen/orogen_plugin.rb
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/orogen/plugins
         RENAME model_exporter_plugin.rb)
 
+install(FILES ${PROJECT_SOURCE_DIR}/lib/orogen_model_exporter.rb
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/ruby/vendor_ruby/)
+
 #add_subdirectory(src)


### PR DESCRIPTION
A proper out of source installation is required for the binary packaging