### PR TITLE
Always register extension

### DIFF
--- a/orogen/orogen_plugin.rb
+++ b/orogen/orogen_plugin.rb
@@ -38,11 +38,7 @@ end
 
 class OroGen::Spec::TaskContext
     def modelExport
-        #puts("#{self.name}")
-        if !find_extension("ModelExporterPlugin")
-            register_extension(ModelExporterPlugin.new)
-            #puts("Model Export active")
-       end
+        register_extension(ModelExporterPlugin.new)
     end
     
 end


### PR DESCRIPTION
The previous guard was a workaround for a bug in orogen which has been fixed,
and for subclassing to work as expected, an extensions should always be registered.