### PR TITLE
add regex to list od boost dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package( Boost COMPONENTS system filesystem)
+find_package( Boost COMPONENTS system regex filesystem)
 rock_library(modelLib
     SOURCES 
         Argument.cpp


### PR DESCRIPTION
closes #10

boost regex is required because of lib_config