### PR TITLE
Change Boost dependencies to use DEPS instead of DEPS_PLAIN

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,8 @@ rock_library(modelLib
     DEPS_PKGCONFIG
         lib_config
         yaml-cpp
-    DEPS_PLAIN 
-        Boost_SYSTEM Boost_FILESYSTEM
+    DEPS
+        Boost::system Boost::filesystem
     )
     
 rock_executable(ymlTest Main.cpp


### PR DESCRIPTION
On ubuntu 22.04, `DEPS_PLAIN` with the `Boost_` deps produces `.pc` files with `Boost::` for libraries.