### PR TITLE
Added missing dependency to typelib

### DIFF
--- a/bin/rock-instantiate
+++ b/bin/rock-instantiate
@@ -1,5 +1,6 @@
 #! /usr/bin/ruby
 
+require 'typelib'
 require 'orogen_model_exporter'
 require 'rock/bundle'
 require 'optparse'
@@ -97,7 +98,7 @@ begin
 		inst = Orocos.get cname
 		begin
 			if options[:config_file]
-				Orocos.apply_conf(inst, options[:config_file], options[:configs])
+				Orocos.apply_conf(inst, options[:config_file], options[:configs], true)
 			else
 				Orocos.conf.apply(inst, options[:configs], true)
 			end


### PR DESCRIPTION
This is a commit back from xrock_gui_model/bin/xrock-resolve-ports to change back to rock-instantiate.
Don't know if this is needed but it has been flagged as a fix by @malter

I've openend the pull-request to possibly merge back.
But i am not yet sure if this is needed any why it had been inserted.